### PR TITLE
Organize project scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,22 @@
 ```
 .
 ├─ scripts/
-│  ├─ preprocess.py
-│  ├─ make_rank_dataset.py
-│  ├─ train_ranker.py
-│  └─ backtest_longterm_bt.py
+│  ├─ prep/
+│  │  └─ preprocess.py
+│  ├─ datasets/
+│  │  ├─ make_ml_table_longterm.py
+│  │  └─ make_rank_dataset.py
+│  ├─ training/
+│  │  ├─ train_ml.py
+│  │  └─ train_ranker.py
+│  ├─ backtests/
+│  │  ├─ backtest_longterm.py
+│  │  └─ backtest_longterm_bt.py
+│  └─ tools/
+│     ├─ backtest_ml.py
+│     ├─ portfolio_backtest.py
+│     ├─ grid_search_sma.py
+│     └─ ...
 ├─ legacy/
 │  └─ backtrader_sma_sent_congress.py
 ├─ data/
@@ -67,7 +79,7 @@ technical indicators and auxiliary features.
 Run it at least once before building datasets:
 
 ```bash
-python scripts/preprocess.py
+python scripts/prep/preprocess.py
 ```
 
 ---
@@ -91,7 +103,7 @@ pip install pandas numpy scikit-learn lightgbm backtrader matplotlib joblib fast
 1. **Preprocess raw data**
 
    ```bash
-   python scripts/preprocess.py
+   python scripts/prep/preprocess.py
    ```
 
    This populates `data/processed/` with per‑ticker files including technical indicators, fundamentals, congress flows and news sentiment.
@@ -99,7 +111,7 @@ pip install pandas numpy scikit-learn lightgbm backtrader matplotlib joblib fast
 2. **Build the dataset**
 
    ```bash
-   python scripts/make_rank_dataset.py --horizon 36
+   python scripts/datasets/make_rank_dataset.py --horizon 36
    ```
 
    This writes: `data/ml/dataset_rank_36m.parquet`.
@@ -109,7 +121,7 @@ pip install pandas numpy scikit-learn lightgbm backtrader matplotlib joblib fast
    The v1 settings that performed best in our tests (robust, smooth ordering):
 
    ```bash
-   python scripts/train_ranker.py \
+   python scripts/training/train_ranker.py \
      --horizon 36 --split 2017-01-01 \
      --rel_bins 3 --eval_k 5,10 \
      --num_leaves 31 --min_data_in_leaf 200 \
@@ -128,7 +140,7 @@ pip install pandas numpy scikit-learn lightgbm backtrader matplotlib joblib fast
 4. **Run the backtest (2017‑01..2020‑04)**
 
    ```bash
-   python scripts/backtest_longterm_bt.py \
+   python scripts/backtests/backtest_longterm_bt.py \
      --horizon 36 --model rank --topk 5 \
      --date_from 2017-01-01 --date_to 2020-04-30 \
      --cash 100000 --commission_bps 10 --save_png

--- a/scripts/backtests/backtest_longterm.py
+++ b/scripts/backtests/backtest_longterm.py
@@ -11,7 +11,7 @@ import pandas as pd
 from pandas import DatetimeIndex, PeriodIndex
 
 # ─────────────────────────── Paths ───────────────────────────
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/scripts/backtests/backtest_longterm_bt.py
+++ b/scripts/backtests/backtest_longterm_bt.py
@@ -15,7 +15,7 @@ from backtrader.utils.date import num2date
 # ---------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/scripts/datasets/make_ml_table_longterm.py
+++ b/scripts/datasets/make_ml_table_longterm.py
@@ -4,7 +4,7 @@ import sys, pathlib, argparse
 import pandas as pd
 import numpy as np
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/scripts/datasets/make_rank_dataset.py
+++ b/scripts/datasets/make_rank_dataset.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 # ───────────────────────── Paths ─────────────────────────
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/scripts/prep/preprocess.py
+++ b/scripts/prep/preprocess.py
@@ -9,7 +9,7 @@ import ta
 from typing import Optional
 
 # ───────── Ajuste de ruta para importar módulos desde src ──────────
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/scripts/tools/backtest_ml.py
+++ b/scripts/tools/backtest_ml.py
@@ -6,7 +6,7 @@ from typing import List
 import pandas as pd
 import numpy as np
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/scripts/tools/backtrader_portfolio_sent_congress.py
+++ b/scripts/tools/backtrader_portfolio_sent_congress.py
@@ -8,7 +8,7 @@ import backtrader as bt
 import backtrader.indicators as btind
 from matplotlib.figure import Figure
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/scripts/tools/backtrader_rules_plot.py
+++ b/scripts/tools/backtrader_rules_plot.py
@@ -9,7 +9,7 @@ import backtrader.indicators as btind
 from backtrader.feeds import PandasData
 from backtrader.utils.date import num2date
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/scripts/tools/diagnose_signal.py
+++ b/scripts/tools/diagnose_signal.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import sys, pathlib, pandas as pd
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path: sys.path.insert(0, str(ROOT))
 
 TKS = ["AAPL","MSFT","NVDA"]

--- a/scripts/tools/grid_search_sma.py
+++ b/scripts/tools/grid_search_sma.py
@@ -1,7 +1,7 @@
 # scripts/grid_search_sma.py
 from __future__ import annotations
 import sys, pathlib, itertools, pandas as pd
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path: sys.path.insert(0, str(ROOT))
 
 from src.evaluation.backtest import run_backtest, summary, BTConfig

--- a/scripts/tools/portfolio_backtest.py
+++ b/scripts/tools/portfolio_backtest.py
@@ -1,7 +1,7 @@
 # scripts/portfolio_backtest.py
 from __future__ import annotations
 import sys, pathlib, pandas as pd
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path: sys.path.insert(0, str(ROOT))
 
 from src.strategy.rules_engine import signal_sma_params

--- a/scripts/tools/quick_backtest.py
+++ b/scripts/tools/quick_backtest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import sys, pathlib, pandas as pd
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path: sys.path.insert(0, str(ROOT))
 
 from src.evaluation.backtest import run_backtest, summary, BTConfig

--- a/scripts/training/train_ml.py
+++ b/scripts/training/train_ml.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import sys, pathlib, argparse, pandas as pd, numpy as np
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path: sys.path.insert(0, str(ROOT))
 
 MLDIR = ROOT / "data/ml"; MLDIR.mkdir(exist_ok=True, parents=True)

--- a/scripts/training/train_ranker.py
+++ b/scripts/training/train_ranker.py
@@ -25,7 +25,7 @@ except Exception as e:
 # ---------------------------------------------------------------------
 # Paths por defecto
 # ---------------------------------------------------------------------
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 DATA_ML = ROOT / "data" / "ml"
 ARTS = ROOT / "artifacts" / "rank"
 ARTS.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- rearrange `scripts/` into prep/datasets/training/backtests/tools
- update script internals for new root paths
- move experimental helpers under `scripts/tools/`
- refresh README paths and layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68870866b95483229fcdb868ac7de9bb